### PR TITLE
Fix navElement Rendering of Link Strings

### DIFF
--- a/bin/lib/nav-element.js
+++ b/bin/lib/nav-element.js
@@ -1,5 +1,5 @@
-module.exports = function navElement(list){
+module.exports = function navElement(list = []){
 	return `<nav>
-		${list.map(link => `<a href="${link}">${link.split('.')[0]}</a>`).join('')}
+		${list.map(link => `<a href="${link}">${link.slice(link.indexOf('/') + 1, link.indexOf('.')).replace(/-/g, ' ')}</a>`).join('')}
 	</nav>`;
 }

--- a/tests/nav-element.test.js
+++ b/tests/nav-element.test.js
@@ -1,0 +1,43 @@
+const test = require('tape');
+const navElement = require('../bin/lib/nav-element');
+
+test('navElement', function(assert){
+	{
+		let message = 'outputs a string';
+		let actual = typeof navElement();
+		let expected = 'string';
+
+		assert.equal(actual, expected, message);
+	}
+
+	{
+		let message = 'removes "/" from text content, but leaves in href if present';
+		let actual = /<a href="\/hello.html">hello<\/a>/.test(navElement(['/hello.html']));
+		let expected = true;
+
+		assert.equal(actual, expected, message);
+
+		actual = /<a href="hello.html">hello<\/a>/.test(navElement(['hello.html']));
+		expected = true;
+
+		assert.equal(actual, expected, message);
+	}
+
+	{
+		let message = 'removes file extension from text content, but leaves in href';
+		let actual = /<a href="\/goodbye.html">goodbye<\/a>/.test(navElement(['/goodbye.html']));
+		let expected = true;
+
+		assert.equal(actual, expected, message);
+	}
+
+	{
+		let message = 'removes "-" from text content, but leaves in href';
+		let actual = /<a href="\/hello-world.html">hello world<\/a>/.test(navElement(['/hello-world.html']));
+		let expected = true;
+
+		assert.equal(actual, expected, message);
+	}
+
+	assert.end();
+});


### PR DESCRIPTION
Text content of each link contained "/" and "-" characters. Removed
those from text content of anchor, but left in href of anchor.
✨ Changes to be committed:
-	modified:   bin/lib/nav-element.js
-	new file:   tests/nav-element.test.js

Fix #10 