### PR TITLE
Updated make-nav-list to Ignore Hidden Files

### DIFF
--- a/bin/lib/make-nav-list.js
+++ b/bin/lib/make-nav-list.js
@@ -1,3 +1,5 @@
 module.exports = function makeNavList(data = {}){
-	return ['/'].concat(Object.keys(data).map(key => `/${key.split('.')[0]}.html`));
+	return ['/'].concat(Object.keys(data)
+		.filter(key => key[0] !== '.')
+		.map(key => `/${key.split('.')[0]}.html`));
 }

--- a/tests/make-nav-list.test.js
+++ b/tests/make-nav-list.test.js
@@ -34,6 +34,17 @@ test('Make Nav List', function(assert){
 		assert.deepEqual(actual, expected, message);
 	}
 
+	{ 
+		let scaffolding = setup(3);
+		scaffolding['.hidden'] = 'secretzzz';
+
+		let message = 'ignores hidden files';
+		let actual = makeNavList(scaffolding);
+		let expected = ['/', '/1.html', '/2.html', '/3.html'];
+
+		assert.deepEqual(actual, expected, message);
+	}
+
 	assert.end();
 });
 


### PR DESCRIPTION
Filter filenames beginning with "." from final output list.

🔥 Changes to be committed:
-	modified:   bin/lib/make-nav-list.js
-	modified:   tests/make-nav-list.test.js

Fix #15 